### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/app/src/main/java/org/tamanegi/atmosphere/TicsUtils.java
+++ b/app/src/main/java/org/tamanegi/atmosphere/TicsUtils.java
@@ -268,7 +268,14 @@ public class TicsUtils
         TypedArray param_ids = res.obtainTypedArray(R.array.unit_params);
         TypedArray params =
             res.obtainTypedArray(param_ids.getResourceId(unit, 0));
+		if (param_ids != null) {
+			param_ids.recycle();
+		}
 
-        return new UnitParameters(params);
+        final UnitParameters returnValueAutoRefactor = new UnitParameters(params);
+		if (params != null) {
+			params.recycle();
+		}
+		return returnValueAutoRefactor;
     }
 }


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary.

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis
